### PR TITLE
User Nav Bar: Removed poker chip routing.

### DIFF
--- a/poker-pals/src/components/navbars/UserNavbar.vue
+++ b/poker-pals/src/components/navbars/UserNavbar.vue
@@ -6,7 +6,7 @@
             <b-collapse id="nav-collapse" is-nav>
                 <!-- Right aligned nav items -->
                 <b-navbar-nav class="ml-auto mx-3">
-                    <b-nav-item to="profile" class="mx-2">
+                    <b-nav-item class="mx-2">
                         <img class="mr-2 img-fluid" src="../../assets/chip.png" alt="Poker Chip"/>
                         <span class="b-nav-text">{{userData.chips}}</span>
                     </b-nav-item>


### PR DESCRIPTION
Clicking on the poker chip in the navigation bar no longer navigates away.