### PR TITLE
small raise fix

### DIFF
--- a/poker-pals/src/components/Poker.vue
+++ b/poker-pals/src/components/Poker.vue
@@ -17,7 +17,8 @@
                     <Display
                             v-bind:myCards="myCards"
                             v-bind:bigBlind="bigBlind"
-                            v-bind:maxBet="players[seatID].chipTotal"
+                            v-bind:chipTotal="players[seatID].chipTotal"
+                            v-bind:bet="players[seatID].bet"
                             v-bind:turnOptions="turnOptions"
                     />
                 </b-row>

--- a/poker-pals/src/components/pokerComponents/Display.vue
+++ b/poker-pals/src/components/pokerComponents/Display.vue
@@ -18,7 +18,7 @@
                 </div>
             </b-col>
             <b-col cols="6" class="actions col-lg-4">
-                <PlayerInputs v-bind:bigBlind="bigBlind" v-bind:maxBet="maxBet" v-bind:turnOptions="turnOptions"/>
+                <PlayerInputs v-bind:bigBlind="bigBlind" v-bind:chipTotal="chipTotal" v-bind:bet="bet" v-bind:turnOptions="turnOptions"/>
             </b-col>
         </b-row>
 </template>
@@ -51,7 +51,7 @@
             PlayerInputs,
         },
         props: [
-            'myCards', 'bigBlind', 'maxBet', 'turnOptions',
+            'myCards', 'bigBlind', 'chipTotal', 'bet', 'turnOptions',
         ],
         data() {
             return {

--- a/poker-pals/src/components/pokerComponents/PlayerInputs.vue
+++ b/poker-pals/src/components/pokerComponents/PlayerInputs.vue
@@ -8,7 +8,7 @@
             </b-form-checkbox>
         </b-row>
         <b-row no-gutters class="my-1">
-            <input id="raiseValue" class="col-8" type="number" :value="raise" :min="bigBlind" :step="bigBlind" :max="maxBet"/>
+            <input id="raiseValue" class="col-8" type="number" :value="raise" :min="bigBlind" :step="bigBlind" :max="chipTotal + bet"/>
             <b-button :disabled="!turnOptions.raise" class="col" variant="dark" v-on:click="makeDecision()">RAISE</b-button>
         </b-row>
         <b-row no-gutters class="my-1">
@@ -31,7 +31,7 @@
         components: {
         },
         props: [
-            'bigBlind', 'maxBet', 'turnOptions',
+            'bigBlind', 'chipTotal', 'bet', 'turnOptions',
         ],
         data() {
             return {


### PR DESCRIPTION
i forgot to mention that the maximum raise to value is dependent on the players chips AND their current bet.

Example: mack enters the table with 10 chips and when the game starts he has initially made the 'big blind' of 1 chip (thus 9 chips left in his 'total'). when it is his turn, his MAX 'raise to value' should be set to 10 (9 chips in total + 1 chip in his current bet), not 9 like it was initially.