### PR TITLE
Poker game logic fix

### DIFF
--- a/poker-pals/src/components/Poker.vue
+++ b/poker-pals/src/components/Poker.vue
@@ -20,6 +20,7 @@
                             v-bind:chipTotal="players[seatID].chipTotal"
                             v-bind:bet="players[seatID].bet"
                             v-bind:turnOptions="turnOptions"
+                            v-bind:flipCheckFold="flipCheckFold"
                     />
                 </b-row>
             </b-col>
@@ -88,6 +89,7 @@ export default {
     data() {
         return {
             checkFold: false, // a toggle that will automatically make a turn decision for you when it is your turn, first see if the player can check, if not then fold
+            flipCheckFold: false, // the value doesn't matter, player inputs is only checking if this variable changes, if so then reset checkfold
             raiseToValue: 0,
             timerReset: true, // use this as a toggle, when the value changes, all timers reset (doesn't matter if its true or false)
             // right now the chat calls back to the poker page to send a report, might want to have the chat run with its own socket
@@ -161,6 +163,7 @@ export default {
                 if(this.seatID !== '' && this.players[this.seatID].timer === true && this.checkFold){
                     // the player wants to check, if can't then fold
                     this.makeDecision('CHECK/FOLD');
+                    this.flipCheckFold = !this.flipCheckFold;
                 }
                 this.timerReset = !this.timerReset;
 

--- a/poker-pals/src/components/pokerComponents/Display.vue
+++ b/poker-pals/src/components/pokerComponents/Display.vue
@@ -18,7 +18,13 @@
                 </div>
             </b-col>
             <b-col cols="6" class="actions col-lg-4">
-                <PlayerInputs v-bind:bigBlind="bigBlind" v-bind:chipTotal="chipTotal" v-bind:bet="bet" v-bind:turnOptions="turnOptions"/>
+                <PlayerInputs 
+                    v-bind:bigBlind="bigBlind" 
+                    v-bind:chipTotal="chipTotal" 
+                    v-bind:bet="bet" 
+                    v-bind:turnOptions="turnOptions"
+                    v-bind:flipCheckFold="flipCheckFold"
+                />
             </b-col>
         </b-row>
 </template>
@@ -51,7 +57,7 @@
             PlayerInputs,
         },
         props: [
-            'myCards', 'bigBlind', 'chipTotal', 'bet', 'turnOptions',
+            'myCards', 'bigBlind', 'chipTotal', 'bet', 'turnOptions', 'flipCheckFold'
         ],
         data() {
             return {

--- a/poker-pals/src/components/pokerComponents/PlayerInputs.vue
+++ b/poker-pals/src/components/pokerComponents/PlayerInputs.vue
@@ -2,7 +2,7 @@
     <b-container fluid class="player-inputs">
         <b-row no-gutters class="my-1">
             <b-button :disabled="!turnOptions.allIn" class="col mr-1" variant="dark" v-on:click="$parent.makeDecision('ALL IN', 0)">ALL IN</b-button>
-            <b-form-checkbox class="offset-2 col-6" switch v-model="checkFold" @change="toggleCheckFoldButton()">
+            <b-form-checkbox id="checkFoldButton" class="offset-2 col-6" switch v-model="checkFold" @change="toggleCheckFoldButton()">
                 <span class="d-none d-sm-block">CHECK/FOLD</span>
                 <span class="d-block d-sm-none">C/F</span>
             </b-form-checkbox>
@@ -31,13 +31,19 @@
         components: {
         },
         props: [
-            'bigBlind', 'chipTotal', 'bet', 'turnOptions',
+            'bigBlind', 'chipTotal', 'bet', 'turnOptions', 'flipCheckFold',
         ],
         data() {
             return {
-                // TODO: bind data with props
                 checkFold: false,
                 raise: this.props.bigBlind()
+            }
+        },
+        watch: {
+            flipCheckFold: function () {
+                this.checkFold = false;
+                this.$parent.toggleCheckFoldButton(this.checkFold);
+                document.getElementById("checkFoldButton").toggled = false;
             }
         },
         methods:{

--- a/server/model/PokerTableAssistant.js
+++ b/server/model/PokerTableAssistant.js
@@ -292,11 +292,12 @@ module.exports = class PokerTableAssistant {
     playerRaiseFinish(raiseToValue){
         this.currentBet = raiseToValue;
         // we don't check for next card reveal because now all decisions are to be reset
+
         for(let i = 0; i < this.tableSeats.length; i++){
             this.tableSeats[i].madeDecision = false;
         }
         this.tableSeats[this.seatTurnID].madeDecision = true; // all but the raiser have had their decisions reset
-        if(this.getNumberOfPlayersAbleToAct() < this.minimumNumberOfPlayersNeededToContinue){ // even though they raised, they could still be the last person able to act (thus raising rather than calling is pointless)
+        if(this.getNumberOfPlayersAbleToAct() < this.minimumNumberOfPlayersNeededToContinue && this.allAblePlayersMadeDecision()){ // even though they raised, they could still be the last person able to act (thus raising rather than calling is pointless)
             this.beginTheShowDown();
         }
         else{

--- a/server/model/PokerTableAssistant.js
+++ b/server/model/PokerTableAssistant.js
@@ -296,8 +296,13 @@ module.exports = class PokerTableAssistant {
             this.tableSeats[i].madeDecision = false;
         }
         this.tableSeats[this.seatTurnID].madeDecision = true; // all but the raiser have had their decisions reset
-        this.findNextTurn();
-        this.setPlayerTurn();
+        if(this.getNumberOfPlayersAbleToAct() < this.minimumNumberOfPlayersNeededToContinue){ // even though they raised, they could still be the last person able to act (thus raising rather than calling is pointless)
+            this.beginTheShowDown();
+        }
+        else{
+            this.findNextTurn();
+            this.setPlayerTurn();
+        }
     }
 
     /**

--- a/server/model/PokerTableAssistant.js
+++ b/server/model/PokerTableAssistant.js
@@ -298,6 +298,9 @@ module.exports = class PokerTableAssistant {
         }
         this.tableSeats[this.seatTurnID].madeDecision = true; // all but the raiser have had their decisions reset
         if(this.getNumberOfPlayersAbleToAct() < this.minimumNumberOfPlayersNeededToContinue && this.allAblePlayersMadeDecision()){ // even though they raised, they could still be the last person able to act (thus raising rather than calling is pointless)
+            for(let i = 0; i < this.tableSeats.length; i++){
+                this.tableSeats[i].resetForNextStage();
+            }
             this.beginTheShowDown();
         }
         else{


### PR DESCRIPTION
not sure how this bug went unnoticed for so long, but here is the scenario:
- you have two players (dev and mack) with chips of 4 and 10 respectively
- dev goes all in with his 4 chips and the turn now moves to mack
- mack now can't check but has the option to fold, call, all in, AND "raise".
- if mack raises then the game by default resets the decisions BUT did not check for number of players able to still act or who made decisions ( this causes the game to ask for macks turn again since dev is all in )

it seems strange but technically a player can raise when no one else can even react to it (they are making a pointless raise when a call is just as good)

note: i saw this strange behaviour during our 'demo' tonight but initially thought it was because the server was restarted