### PR TITLE
Table leave join fix

### DIFF
--- a/server/model/PokerTable.js
+++ b/server/model/PokerTable.js
@@ -240,7 +240,6 @@ class PokerTable {
             let itWasTheirTurn = false;
             if (this.assistant.wasItTheirTurn(userID)) { itWasTheirTurn = true; } // it was their turn
             seat.resetSeat();
-            //let newTimeout = false;
             if (itWasTheirTurn) { // it was their turn, find the next one
                 clearTimeout(this.timeout); // player made an action, stop the timeout
                 this.assistant.playerFoldFinish(); // because it was their turn we can treat it like a fold


### PR DESCRIPTION
the problem was checking to see how many players are still in play, note if a player leaves a table and joins back in quickly they can still collect the chips from their bet that no one else could claim.

example:
- dev and mack join a game of 20 table chips each
- dev is the small blind (1 chip), mack is the big blind (2 chips)
- when it is dev's turn, mack then jumps from the table (forfeiting the hand) and then jumps back in
- the game declares dev the winner and based on his 1 chip bet he collects 1 chip from mack
- mack originally bet 2 chips and loses 1 chip, the remaining chip is sent back to his table chip count
- the next game starts with dev having 21 chips and mack having 21 chips (even though he rejoined with 20 chips)